### PR TITLE
Add tox.ini to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ subber.cfg
 */venv/*
 venv/*
 venv
+*.egg
+*.egg-info/
+.tox/
+htmlcov/
+.coverage
+.coverage.*
+.cache
+cover/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
+sudo: false
 language: python
 python:
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
-
-install:
-  - pip3 install -r requirements.txt
-  - pip3 install -r requirements-test.txt
-  - pip3 install .
-
-script:
-  - flake8
-  - python -m unittest discover -v
-
+install: pip install tox-travis
+script: tox
 notifications:
   email: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,57 @@
+[tox]
+minversion = 2.3.1
+envlist = py{35,36},pep8
+skipdist = True
+
+[testenv]
+usedevelop = True
+basepython = python3
+install_command = pip install {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  LANGUAGE=en_US
+  LC_ALL=en_US.utf-8
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/requirements-test.txt
+commands =
+  find . -type f -name "*.pyc" -delete
+whitelist_externals =
+  find
+
+[testenv:venv]
+commands = {posargs}
+
+[testenv:py35]
+basepython = python3.5
+commands =
+  {[testenv]commands}
+  python -m unittest discover -v
+
+[testenv:py36]
+basepython = python3.6
+commands =
+  {[testenv]commands}
+  python -m unittest discover -v
+
+[testenv:cover]
+deps =
+  {[testenv]deps}
+  coverage
+setenv =
+  {[testenv]setenv}
+commands =
+  coverage erase
+  python -m coverage run --source subber -m unittest discover -s tests
+  coverage html -d cover
+  coverage report -m
+
+[testenv:pep8]
+description = Run style checks.
+commands = flake8 {posargs}
+
+[flake8]
+filename = *.py
+show-source = True
+enable-extensions = H203,H904
+exclude = .venv,.git,.tox,build,dist,*lib/python*,*egg,vendor


### PR DESCRIPTION
This patch set adds a basic tox.ini to the project providing linting,
unittesting, and test coverage.  This patch set also updates .gitignore so
it does not pick up unnecessary build artifacts created and the travis.yml
CI to use the tox.ini.

Signed-off-by: Tin Lam <tin@irrational.io>