### PR TITLE
Add bandit security scanning via tox

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 blinker==1.4
 flask_testing==0.7.1
 flake8==3.5.0
+bandit>=1.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,9 @@ commands =
 description = Run style checks.
 commands = flake8 {posargs}
 
+[testenv:bandit]
+commands = bandit -r subber -x tests
+
 [flake8]
 filename = *.py
 show-source = True


### PR DESCRIPTION
This change adds another tox option 'bandit' in order to
run the security scanning tool bandit against the code base.