### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 
 install:
 	pip3 install -r requirements.txt
-	pip install .
+	pip3 install .
 
 lint:
 	tox -e pep8


### PR DESCRIPTION
Fix Makefile's install target to consistently use pip3.

Signed-off-by: Tin Lam <tin@irrational.io>