### PR TITLE
add docker build in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
-sudo: false
+sudo: required
 language: python
 python:
   - "3.5"
   - "3.6"
+services:
+  - docker
+
 install: pip install tox-travis
-script: tox
+
+before_script:
+  - tox
+
+script:
+  - docker build -t subber:subber .
+
+
 notifications:
   email: false
+
+


### PR DESCRIPTION
fix #53 
I add a basic build command after all the test pass.
After this we can add a Docker-Hub push command that provide user to direct pull ability.
`docker push subber/subber` 
with added login details.
