### PR TITLE
Load config in subber.py

### DIFF
--- a/subber/reddit.py
+++ b/subber/reddit.py
@@ -16,7 +16,7 @@ import logging
 import praw
 import prawcore
 
-from subber import config, util
+from subber import util
 
 logger = logging.getLogger(__name__)
 
@@ -24,13 +24,12 @@ logger = logging.getLogger(__name__)
 class Reddit(object):
     """Reddit API session"""
 
-    def __init__(self):
-        self._cfg = config.get_api_config()
-        self._session = praw.Reddit(client_id=self._cfg['id'],
-                                    client_secret=self._cfg['secret'],
-                                    password=self._cfg['password'],
+    def __init__(self, client_id, client_secret, password, username):
+        self._session = praw.Reddit(client_id=client_id,
+                                    client_secret=client_secret,
+                                    password=password,
                                     user_agent='web app',
-                                    username=self._cfg['username'])
+                                    username=username)
 
         # Verify connection
         try:

--- a/subber/subber.py
+++ b/subber/subber.py
@@ -16,7 +16,7 @@ import logging
 
 import flask
 
-from subber import reddit
+from subber import config, reddit
 
 app = flask.Flask(__name__)
 logger = logging.getLogger(__name__)
@@ -93,7 +93,11 @@ def init_logging():
 
 def init_session():
     """Init Reddit API session"""
-    return reddit.Reddit().get_session()
+    cfg = config.get_config()
+    return reddit.Reddit(cfg['id'],
+                         cfg['secret'],
+                         cfg['password'],
+                         cfg['username']).get_session()
 
 
 init_logging()

--- a/tests/test_subber.py
+++ b/tests/test_subber.py
@@ -19,8 +19,9 @@ import flask_testing
 
 class TestSubber(flask_testing.TestCase):
 
+    @patch('subber.config.get_config')
     @patch('subber.reddit.Reddit')
-    def create_app(self, mock_session):
+    def create_app(self, mock_session, mock_config):
         # Mock session return value
         redditor = {'name': 'u/test',
                     'created': 2545896143}


### PR DESCRIPTION
This commit aims to refactor config loading so it is loaded in
subber.py instead of reddit.py

Closes #42 