### PR TITLE
Makefile: remove errant period character

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ run:
 		   --detach \
 		   --publish 8000:8000 \
 		   --volume $(shell PWD)/subber.cfg:/subber/subber.cfg \
-		   $(IMAGE_NAME):$(IMAGE_TAG) .
+		   $(IMAGE_NAME):$(IMAGE_TAG)
 
 stop:
 	docker rm -f $(APP_NAME)


### PR DESCRIPTION
In the Makefile recipe `run`, there is an errant period character at
the end of the build statements that causes the docker run command to
fail. This commit removes it.