### PR TITLE
Fix utc_epoch_sec_to_years

### DIFF
--- a/subber/util.py
+++ b/subber/util.py
@@ -11,29 +11,25 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import datetime
+from datetime import datetime
 import logging
 
 logger = logging.getLogger(__name__)
 
 
 def utc_epoch_sec_to_years(sec):
-    """Converts seconds from UTC epoch to elapsed time from current time"""
+    """Converts seconds from UTC epoch to elapsed time from current time."""
 
     logging.debug('Converting {} seconds from UTC epoch to years to '
                   'date'.format(sec))
 
-    try:
-        # Elapsed seconds
-        elapsed_sec = datetime.now() - sec
-
-        # Elapsed days from time
-        days = datetime.timedelta(seconds=elapsed_sec).days
-
-        # Reddit rounds years this way on their website
-        # Subber does the same for consistency
-        return int(days/365)
-
-    except Exception:
+    if not isinstance(sec, (int, float)):
         logging.error('Unable to calculate years to date from UTC epoch '
                       'timestamp')
+        return -1
+
+    time = datetime.utcnow() - datetime.utcfromtimestamp(sec)
+
+    # Reddit rounds years this way on their website
+    # Subber does the same for consistency
+    return int(time.days/365)

--- a/tests/test_reddit.py
+++ b/tests/test_reddit.py
@@ -11,11 +11,13 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from datetime import datetime
+from datetime import timedelta
 import unittest
 from unittest.mock import Mock, patch
 
 from subber import reddit
-
+from subber import util
 
 class TestReddit(unittest.TestCase):
     @patch('subber.reddit._get_similar_users')
@@ -170,6 +172,30 @@ class TestReddit(unittest.TestCase):
 
         mock_years.assert_called_with(subreddit.created)
         mock_session.subreddit.assert_called_with(sub_param)
+
+
+    def test_util_utc_epoch_sec_to_years(self):
+        def unix_time_seconds(time):
+            epoch = datetime.utcfromtimestamp(0)
+            return (time - epoch).total_seconds()
+
+        def unix_time_years(time):
+            epoch = datetime.utcfromtimestamp(0)
+            return int((time - epoch).total_seconds() / (60*60*24*365))
+
+        time_now = unix_time_seconds(datetime.utcnow())
+        one_year = time_now - timedelta(days=365).total_seconds()
+        five_years = time_now - (timedelta(days=365).total_seconds() * 5)
+
+        years_epoch = unix_time_years(datetime.utcnow())
+
+        self.assertEqual(util.utc_epoch_sec_to_years(time_now), 0)
+        self.assertEqual(util.utc_epoch_sec_to_years(one_year), 1)
+        self.assertEqual(util.utc_epoch_sec_to_years(five_years), 5)
+
+        self.assertEqual(util.utc_epoch_sec_to_years('time'), -1)
+        self.assertEqual(util.utc_epoch_sec_to_years(0), years_epoch)
+        self.assertEqual(util.utc_epoch_sec_to_years(True), years_epoch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change fixes the issue where the util function to calculate years
from seconds since epoch was failing due to a previous change.

Also added a test for the specific function.

fixes #59 